### PR TITLE
fix: use compatibility addresses by default

### DIFF
--- a/lib/service/Service.ts
+++ b/lib/service/Service.ts
@@ -22,7 +22,7 @@ class Service {
    * Creates a new Swap from the chain to Lightning
    */
   public createSwap = (pairId: string, orderSide: OrderSide, invoice: string, refundPublicKey: string) => {
-    return this.boltz.createSwap(pairId, orderSide, invoice, refundPublicKey, OutputType.BECH32);
+    return this.boltz.createSwap(pairId, orderSide, invoice, refundPublicKey, OutputType.COMPATIBILITY);
   }
 }
 


### PR DESCRIPTION
Hardly any wallet supports bech32 on LTC (not even the LND one) and therefore the default address type should be changed to `compatibility`. 