### PR TITLE
Stringify maps

### DIFF
--- a/lib/Utils.ts
+++ b/lib/Utils.ts
@@ -58,13 +58,6 @@ export const stringify = (object: any) => {
 };
 
 /**
- * Turn a map into an array
- */
-export const mapToArray = (map: Map<any, any>) => {
-  return Array.from(map.entries());
-};
-
-/**
  * Turn a map into an object
  */
 export const mapToObject = (map: Map<any, any>) => {

--- a/lib/rates/RateProvider.ts
+++ b/lib/rates/RateProvider.ts
@@ -1,7 +1,7 @@
 import Logger from '../Logger';
 import CryptoCompare from './CryptoCompare';
 import { PairInstance } from 'lib/consts/Database';
-import { getPairId, stringify, mapToArray } from '../Utils';
+import { getPairId, stringify, mapToObject } from '../Utils';
 
 // TODO: add unit tests
 // TODO: make rate update interval configurable
@@ -32,7 +32,7 @@ class RateProvider {
       }
     });
 
-    this.logger.silly(`Prepared data for requests to CryptoCompare: ${stringify(mapToArray(this.baseAssetsMap))}`);
+    this.logger.silly(`Prepared data for requests to CryptoCompare: ${stringify(mapToObject(this.baseAssetsMap))}`);
 
     await this.updateRates();
 
@@ -60,7 +60,7 @@ class RateProvider {
 
     await Promise.all(promises);
 
-    this.logger.debug(`Updated rates: ${stringify(mapToArray(this.rates))}`);
+    this.logger.debug(`Updated rates: ${stringify(mapToObject(this.rates))}`);
   }
 
 }

--- a/lib/service/Service.ts
+++ b/lib/service/Service.ts
@@ -1,5 +1,4 @@
 import { EventEmitter } from 'events';
-import uuidv4 from 'uuid/v4';
 import Logger from '../Logger';
 import Database from '../db/Database';
 import BoltzClient from '../boltz/BoltzClient';
@@ -7,7 +6,7 @@ import { OrderSide, OutputType, CurrencyInfo } from '../proto/boltzrpc_pb';
 import PairRepository from './PairRepository';
 import RateProvider from '../rates/RateProvider';
 import { PairInstance, PairFactory } from '../consts/Database';
-import { splitPairId, stringify, mapToArray, generateId, mapToObject } from '../Utils';
+import { splitPairId, stringify, generateId, mapToObject } from '../Utils';
 import Errors from './Errors';
 
 type PairConfig = {
@@ -122,7 +121,7 @@ class Service extends EventEmitter {
       }
     });
 
-    this.logger.verbose(`Initialised ${this.pairs.size} pairs: ${stringify(mapToArray(this.pairs))}`);
+    this.logger.verbose(`Initialised ${this.pairs.size} pairs: ${stringify(mapToObject(this.pairs))}`);
 
     // Listen to events of the Boltz client
     this.boltz.on('transaction.confirmed', (transactionHash: string, outputAddress: string) => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,7 +21,7 @@
     "noImplicitThis": true, /* Raise error on 'this' expressions with an implied 'any' type. */
     "alwaysStrict": true, /* Parse in strict mode and emit "use strict" for each source file. */
     /* Additional Checks */
-    "noUnusedLocals": false, /* Report errors on unused locals. */
+    "noUnusedLocals": true, /* Report errors on unused locals. */
     "noUnusedParameters": true, /* Report errors on unused parameters. */
     "noImplicitReturns": true, /* Report error when not all code paths in function return a value. */
     "noFallthroughCasesInSwitch": true, /* Report errors for fallthrough cases in switch statement. */

--- a/tslint.json
+++ b/tslint.json
@@ -6,7 +6,6 @@
     "max-line-length": [true, 150],
     "no-else-after-return": false,
     "function-name": false,
-    "no-unused-variable": false, // TODO: rule disabled during early development stages, should be reenabled later
     "align": false,
     "typedef-whitespace": [
       true, {


### PR DESCRIPTION
This PR:

- changes to way Maps are converted to strings. Because `JSON.stringify` doesn't work with the data type `Map` we have to use custom functions. At first I thought that converting `Maps`s into arrays would be best for printing the result in the console but a plain `object` does represent the data structure of a `Map` better imo.
- disallows unused variables (will result in a compilation errors)