### PR TITLE
feat: add generation of BIP21 payment requests

### DIFF
--- a/lib/proto/boltzrpc_pb.d.ts
+++ b/lib/proto/boltzrpc_pb.d.ts
@@ -577,9 +577,6 @@ export class CreateSwapResponse extends jspb.Message {
     getExpectedAmount(): number;
     setExpectedAmount(value: number): void;
 
-    getBip21(): string;
-    setBip21(value: string): void;
-
 
     serializeBinary(): Uint8Array;
     toObject(includeInstance?: boolean): CreateSwapResponse.AsObject;
@@ -597,7 +594,6 @@ export namespace CreateSwapResponse {
         timeoutBlockHeight: number,
         address: string,
         expectedAmount: number,
-        bip21: string,
     }
 }
 

--- a/lib/proto/boltzrpc_pb.js
+++ b/lib/proto/boltzrpc_pb.js
@@ -3864,8 +3864,7 @@ proto.boltzrpc.CreateSwapResponse.toObject = function(includeInstance, msg) {
     redeemScript: jspb.Message.getFieldWithDefault(msg, 1, ""),
     timeoutBlockHeight: jspb.Message.getFieldWithDefault(msg, 2, 0),
     address: jspb.Message.getFieldWithDefault(msg, 3, ""),
-    expectedAmount: jspb.Message.getFieldWithDefault(msg, 4, 0),
-    bip21: jspb.Message.getFieldWithDefault(msg, 5, "")
+    expectedAmount: jspb.Message.getFieldWithDefault(msg, 4, 0)
   };
 
   if (includeInstance) {
@@ -3917,10 +3916,6 @@ proto.boltzrpc.CreateSwapResponse.deserializeBinaryFromReader = function(msg, re
     case 4:
       var value = /** @type {number} */ (reader.readInt64());
       msg.setExpectedAmount(value);
-      break;
-    case 5:
-      var value = /** @type {string} */ (reader.readString());
-      msg.setBip21(value);
       break;
     default:
       reader.skipField();
@@ -3976,13 +3971,6 @@ proto.boltzrpc.CreateSwapResponse.serializeBinaryToWriter = function(message, wr
   if (f !== 0) {
     writer.writeInt64(
       4,
-      f
-    );
-  }
-  f = message.getBip21();
-  if (f.length > 0) {
-    writer.writeString(
-      5,
       f
     );
   }
@@ -4046,21 +4034,6 @@ proto.boltzrpc.CreateSwapResponse.prototype.getExpectedAmount = function() {
 /** @param {number} value */
 proto.boltzrpc.CreateSwapResponse.prototype.setExpectedAmount = function(value) {
   jspb.Message.setField(this, 4, value);
-};
-
-
-/**
- * optional string bip21 = 5;
- * @return {string}
- */
-proto.boltzrpc.CreateSwapResponse.prototype.getBip21 = function() {
-  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 5, ""));
-};
-
-
-/** @param {string} value */
-proto.boltzrpc.CreateSwapResponse.prototype.setBip21 = function(value) {
-  jspb.Message.setField(this, 5, value);
 };
 
 

--- a/lib/service/PaymentRequestUtils.ts
+++ b/lib/service/PaymentRequestUtils.ts
@@ -1,0 +1,19 @@
+/**
+ * Get the BIP21 prefix for a currency
+ */
+const getBip21Prefix = (symbol: string) => {
+  return symbol === 'BTC' ? 'bitcoin' : 'litecoin';
+};
+
+/**
+ * Encode a BIP21 payment request
+ */
+export const encodeBip21 = (symbol: string, address: string, satoshis: number, label?: string) => {
+  let request = `${getBip21Prefix(symbol)}:${address}?value=${satoshis / 100000000}`;
+
+  if (label) {
+    request += `&label=${label.replace(/ /g, '%20')}`;
+  }
+
+  return request;
+};

--- a/proto/boltzrpc.proto
+++ b/proto/boltzrpc.proto
@@ -146,7 +146,6 @@ message CreateSwapResponse {
   int64 timeout_block_height = 2;
   string address = 3;
   int64 expected_amount = 4;
-  string bip21 = 5;
 }
 
 message CreateReverseSwapRequest {


### PR DESCRIPTION
Since BIP21 payment requests should be generated in the middleware and not the backend this PR adds to the code of the middleware what https://github.com/BoltzExchange/boltz-backend/pull/39 removed from the backend.