### PR TITLE
feat: add API endpoint for creating reverse swaps

### DIFF
--- a/lib/api/Api.ts
+++ b/lib/api/Api.ts
@@ -37,6 +37,7 @@ class Api {
     this.app.route('/broadcasttransaction').post(controller.broadcastTransaction);
 
     this.app.route('/createswap').post(controller.createSwap);
+    this.app.route('/createreverseswap').post(controller.createReverseSwap);
 
     this.app.route('/swapstatus').get(controller.swapStatus);
   }

--- a/lib/api/Controller.ts
+++ b/lib/api/Controller.ts
@@ -71,6 +71,26 @@ class Controller {
     }
   }
 
+  public createReverseSwap = async (req: Request, res: Response) => {
+    try {
+      const { pairId, orderSide, claimPublicKey, amount } = this.validateBody(req.body, [
+        { name: 'pairId', type: 'string' },
+        { name: 'orderSide', type: 'string' },
+        { name: 'claimPublicKey', type: 'string' },
+        { name: 'amount', type: 'number' },
+      ]);
+
+      const response = await this.service.createReverseSwap(pairId, orderSide, claimPublicKey, amount);
+
+      this.logger.verbose(`Created reverse swap with id: ${response.id}`);
+      this.logger.silly(`Reverse swap ${response.id}: ${stringify(response)}`);
+
+      this.swapCreatedResponse(res, response);
+    } catch (error) {
+      this.writeErrorResponse(res, error);
+    }
+  }
+
   public swapStatus = (req: Request, res: Response) => {
     try {
       const { id } = this.validateBody(req.query, [
@@ -84,6 +104,10 @@ class Controller {
       });
 
       this.pendingSwaps.set(id, res);
+
+      res.on('close', () => {
+        this.pendingSwaps.delete(id);
+      });
     } catch (error) {
       this.writeErrorResponse(res, error);
     }

--- a/lib/proto/boltzrpc_grpc_pb.js
+++ b/lib/proto/boltzrpc_grpc_pb.js
@@ -310,7 +310,7 @@ var BoltzService = exports.BoltzService = {
     responseSerialize: serialize_boltzrpc_SubscribeTransactionsResponse,
     responseDeserialize: deserialize_boltzrpc_SubscribeTransactionsResponse,
   },
-  // Subscribes to a stream of invoices paid by Boltz 
+  // Subscribes to a stream of settled invoices and those paid by Boltz 
   subscribeInvoices: {
     path: '/boltzrpc.Boltz/SubscribeInvoices',
     requestStream: false,

--- a/lib/proto/boltzrpc_pb.d.ts
+++ b/lib/proto/boltzrpc_pb.d.ts
@@ -499,6 +499,9 @@ export namespace SubscribeInvoicesRequest {
 }
 
 export class SubscribeInvoicesResponse extends jspb.Message { 
+    getEvent(): InvoiceEvent;
+    setEvent(value: InvoiceEvent): void;
+
     getInvoice(): string;
     setInvoice(value: string): void;
 
@@ -515,6 +518,7 @@ export class SubscribeInvoicesResponse extends jspb.Message {
 
 export namespace SubscribeInvoicesResponse {
     export type AsObject = {
+        event: InvoiceEvent,
         invoice: string,
     }
 }
@@ -645,11 +649,14 @@ export class CreateReverseSwapResponse extends jspb.Message {
     getRedeemScript(): string;
     setRedeemScript(value: string): void;
 
-    getTransaction(): string;
-    setTransaction(value: string): void;
+    getLockupAddress(): string;
+    setLockupAddress(value: string): void;
 
-    getTransactionHash(): string;
-    setTransactionHash(value: string): void;
+    getLockupTransaction(): string;
+    setLockupTransaction(value: string): void;
+
+    getLockupTransactionHash(): string;
+    setLockupTransactionHash(value: string): void;
 
 
     serializeBinary(): Uint8Array;
@@ -666,8 +673,9 @@ export namespace CreateReverseSwapResponse {
     export type AsObject = {
         invoice: string,
         redeemScript: string,
-        transaction: string,
-        transactionHash: string,
+        lockupAddress: string,
+        lockupTransaction: string,
+        lockupTransactionHash: string,
     }
 }
 
@@ -680,4 +688,9 @@ export enum OutputType {
 export enum OrderSide {
     BUY = 0,
     SELL = 1,
+}
+
+export enum InvoiceEvent {
+    PAID = 0,
+    SETTLED = 1,
 }

--- a/lib/proto/boltzrpc_pb.js
+++ b/lib/proto/boltzrpc_pb.js
@@ -25,6 +25,7 @@ goog.exportSymbol('proto.boltzrpc.GetInfoRequest', null, global);
 goog.exportSymbol('proto.boltzrpc.GetInfoResponse', null, global);
 goog.exportSymbol('proto.boltzrpc.GetTransactionRequest', null, global);
 goog.exportSymbol('proto.boltzrpc.GetTransactionResponse', null, global);
+goog.exportSymbol('proto.boltzrpc.InvoiceEvent', null, global);
 goog.exportSymbol('proto.boltzrpc.ListenOnAddressRequest', null, global);
 goog.exportSymbol('proto.boltzrpc.ListenOnAddressResponse', null, global);
 goog.exportSymbol('proto.boltzrpc.LndChannels', null, global);
@@ -3415,7 +3416,8 @@ proto.boltzrpc.SubscribeInvoicesResponse.prototype.toObject = function(opt_inclu
  */
 proto.boltzrpc.SubscribeInvoicesResponse.toObject = function(includeInstance, msg) {
   var f, obj = {
-    invoice: jspb.Message.getFieldWithDefault(msg, 1, "")
+    event: jspb.Message.getFieldWithDefault(msg, 1, 0),
+    invoice: jspb.Message.getFieldWithDefault(msg, 2, "")
   };
 
   if (includeInstance) {
@@ -3453,6 +3455,10 @@ proto.boltzrpc.SubscribeInvoicesResponse.deserializeBinaryFromReader = function(
     var field = reader.getFieldNumber();
     switch (field) {
     case 1:
+      var value = /** @type {!proto.boltzrpc.InvoiceEvent} */ (reader.readEnum());
+      msg.setEvent(value);
+      break;
+    case 2:
       var value = /** @type {string} */ (reader.readString());
       msg.setInvoice(value);
       break;
@@ -3485,10 +3491,17 @@ proto.boltzrpc.SubscribeInvoicesResponse.prototype.serializeBinary = function() 
  */
 proto.boltzrpc.SubscribeInvoicesResponse.serializeBinaryToWriter = function(message, writer) {
   var f = undefined;
+  f = message.getEvent();
+  if (f !== 0.0) {
+    writer.writeEnum(
+      1,
+      f
+    );
+  }
   f = message.getInvoice();
   if (f.length > 0) {
     writer.writeString(
-      1,
+      2,
       f
     );
   }
@@ -3496,17 +3509,32 @@ proto.boltzrpc.SubscribeInvoicesResponse.serializeBinaryToWriter = function(mess
 
 
 /**
- * optional string invoice = 1;
+ * optional InvoiceEvent event = 1;
+ * @return {!proto.boltzrpc.InvoiceEvent}
+ */
+proto.boltzrpc.SubscribeInvoicesResponse.prototype.getEvent = function() {
+  return /** @type {!proto.boltzrpc.InvoiceEvent} */ (jspb.Message.getFieldWithDefault(this, 1, 0));
+};
+
+
+/** @param {!proto.boltzrpc.InvoiceEvent} value */
+proto.boltzrpc.SubscribeInvoicesResponse.prototype.setEvent = function(value) {
+  jspb.Message.setField(this, 1, value);
+};
+
+
+/**
+ * optional string invoice = 2;
  * @return {string}
  */
 proto.boltzrpc.SubscribeInvoicesResponse.prototype.getInvoice = function() {
-  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 1, ""));
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 2, ""));
 };
 
 
 /** @param {string} value */
 proto.boltzrpc.SubscribeInvoicesResponse.prototype.setInvoice = function(value) {
-  jspb.Message.setField(this, 1, value);
+  jspb.Message.setField(this, 2, value);
 };
 
 
@@ -4363,8 +4391,9 @@ proto.boltzrpc.CreateReverseSwapResponse.toObject = function(includeInstance, ms
   var f, obj = {
     invoice: jspb.Message.getFieldWithDefault(msg, 1, ""),
     redeemScript: jspb.Message.getFieldWithDefault(msg, 2, ""),
-    transaction: jspb.Message.getFieldWithDefault(msg, 3, ""),
-    transactionHash: jspb.Message.getFieldWithDefault(msg, 4, "")
+    lockupAddress: jspb.Message.getFieldWithDefault(msg, 3, ""),
+    lockupTransaction: jspb.Message.getFieldWithDefault(msg, 4, ""),
+    lockupTransactionHash: jspb.Message.getFieldWithDefault(msg, 5, "")
   };
 
   if (includeInstance) {
@@ -4411,11 +4440,15 @@ proto.boltzrpc.CreateReverseSwapResponse.deserializeBinaryFromReader = function(
       break;
     case 3:
       var value = /** @type {string} */ (reader.readString());
-      msg.setTransaction(value);
+      msg.setLockupAddress(value);
       break;
     case 4:
       var value = /** @type {string} */ (reader.readString());
-      msg.setTransactionHash(value);
+      msg.setLockupTransaction(value);
+      break;
+    case 5:
+      var value = /** @type {string} */ (reader.readString());
+      msg.setLockupTransactionHash(value);
       break;
     default:
       reader.skipField();
@@ -4460,17 +4493,24 @@ proto.boltzrpc.CreateReverseSwapResponse.serializeBinaryToWriter = function(mess
       f
     );
   }
-  f = message.getTransaction();
+  f = message.getLockupAddress();
   if (f.length > 0) {
     writer.writeString(
       3,
       f
     );
   }
-  f = message.getTransactionHash();
+  f = message.getLockupTransaction();
   if (f.length > 0) {
     writer.writeString(
       4,
+      f
+    );
+  }
+  f = message.getLockupTransactionHash();
+  if (f.length > 0) {
+    writer.writeString(
+      5,
       f
     );
   }
@@ -4508,32 +4548,47 @@ proto.boltzrpc.CreateReverseSwapResponse.prototype.setRedeemScript = function(va
 
 
 /**
- * optional string transaction = 3;
+ * optional string lockup_address = 3;
  * @return {string}
  */
-proto.boltzrpc.CreateReverseSwapResponse.prototype.getTransaction = function() {
+proto.boltzrpc.CreateReverseSwapResponse.prototype.getLockupAddress = function() {
   return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 3, ""));
 };
 
 
 /** @param {string} value */
-proto.boltzrpc.CreateReverseSwapResponse.prototype.setTransaction = function(value) {
+proto.boltzrpc.CreateReverseSwapResponse.prototype.setLockupAddress = function(value) {
   jspb.Message.setField(this, 3, value);
 };
 
 
 /**
- * optional string transaction_hash = 4;
+ * optional string lockup_transaction = 4;
  * @return {string}
  */
-proto.boltzrpc.CreateReverseSwapResponse.prototype.getTransactionHash = function() {
+proto.boltzrpc.CreateReverseSwapResponse.prototype.getLockupTransaction = function() {
   return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 4, ""));
 };
 
 
 /** @param {string} value */
-proto.boltzrpc.CreateReverseSwapResponse.prototype.setTransactionHash = function(value) {
+proto.boltzrpc.CreateReverseSwapResponse.prototype.setLockupTransaction = function(value) {
   jspb.Message.setField(this, 4, value);
+};
+
+
+/**
+ * optional string lockup_transaction_hash = 5;
+ * @return {string}
+ */
+proto.boltzrpc.CreateReverseSwapResponse.prototype.getLockupTransactionHash = function() {
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 5, ""));
+};
+
+
+/** @param {string} value */
+proto.boltzrpc.CreateReverseSwapResponse.prototype.setLockupTransactionHash = function(value) {
+  jspb.Message.setField(this, 5, value);
 };
 
 
@@ -4552,6 +4607,14 @@ proto.boltzrpc.OutputType = {
 proto.boltzrpc.OrderSide = {
   BUY: 0,
   SELL: 1
+};
+
+/**
+ * @enum {number}
+ */
+proto.boltzrpc.InvoiceEvent = {
+  PAID: 0,
+  SETTLED: 1
 };
 
 goog.object.extend(exports, proto.boltzrpc);

--- a/proto/boltzrpc.proto
+++ b/proto/boltzrpc.proto
@@ -24,7 +24,7 @@ service Boltz {
   /* Subscribes to a stream of confirmed transactions to addresses that were specified with "ListenOnAddress" */
   rpc SubscribeTransactions (SubscribeTransactionsRequest) returns (stream SubscribeTransactionsResponse);
 
-  /* Subscribes to a stream of invoices paid by Boltz */
+  /* Subscribes to a stream of settled invoices and those paid by Boltz */
   rpc SubscribeInvoices (SubscribeInvoicesRequest) returns (stream SubscribeInvoicesResponse);
 
   /* Creates a new Swap from the chain to Lightning */
@@ -43,6 +43,11 @@ enum OutputType {
 enum OrderSide {
   BUY = 0;
   SELL = 1;
+}
+
+enum InvoiceEvent {
+  PAID = 0;
+  SETTLED = 1;
 }
 
 message GetInfoRequest {}
@@ -129,7 +134,8 @@ message SubscribeTransactionsResponse {
 
 message SubscribeInvoicesRequest {}
 message SubscribeInvoicesResponse {
-  string invoice = 1;
+  InvoiceEvent event = 1;
+  string invoice = 2;
 }
 
 message CreateSwapRequest {
@@ -160,6 +166,7 @@ message CreateReverseSwapRequest {
 message CreateReverseSwapResponse {
   string invoice = 1;
   string redeem_script = 2;
-  string transaction = 3;
-  string transaction_hash = 4;
+  string lockup_address = 3;
+  string lockup_transaction = 4;
+  string lockup_transaction_hash = 5;
 }


### PR DESCRIPTION
Depends on https://github.com/BoltzExchange/boltz-backend/pull/62

This PR:

- adds an API method to create reverse Swaps (`/createreverseswap`)
- updates `/swapstatus` so that it is compatible with reverse swaps