### PR TITLE
feat: optional hardcoded rates

### DIFF
--- a/lib/consts/Database.ts
+++ b/lib/consts/Database.ts
@@ -17,6 +17,7 @@ export type SequelizeAttributes<T extends { [key: string]: any }> = {
 export type PairFactory = {
   base: string;
   quote: string;
+  rate?: number;
 };
 
 export type PairAttributes = PairFactory & {

--- a/lib/db/models/Pair.ts
+++ b/lib/db/models/Pair.ts
@@ -7,6 +7,7 @@ export default (sequelize: Sequelize.Sequelize, dataTypes: Sequelize.DataTypes) 
     id: { type: dataTypes.STRING, primaryKey: true },
     base: { type: dataTypes.STRING, allowNull: false },
     quote: { type: dataTypes.STRING, allowNull: false },
+    rate: { type: dataTypes.FLOAT, allowNull: true },
   };
 
   const options: Sequelize.DefineOptions<db.PairInstance> = {

--- a/lib/rates/RateProvider.ts
+++ b/lib/rates/RateProvider.ts
@@ -23,6 +23,14 @@ class RateProvider {
    */
   public init = async (pairs: PairInstance[]) => {
     pairs.forEach((pair) => {
+      // If a pair has a hardcoded rate the CryptoCompare rate doesn't have to be queried
+      if (pair.rate) {
+        this.logger.debug(`Setting hardcoded rate for pair ${pair.id}: ${pair.rate}`);
+
+        this.rates.set(pair.id, pair.rate);
+        return;
+      }
+
       const baseAssets = this.baseAssetsMap.get(pair.quote);
 
       if (baseAssets) {


### PR DESCRIPTION
In order to support swaps on the same currency it has to be possible to hardcode a rate (also nice to have in case one wants to support swaps on currencies that are not available on the CryptoCompare API). 