### PR TITLE
fix: add X-Accel-Buffering header to stop status reponse

### DIFF
--- a/lib/api/Controller.ts
+++ b/lib/api/Controller.ts
@@ -100,6 +100,7 @@ class Controller {
       res.writeHead(200, {
         'Content-Type': 'text/event-stream',
         'Cache-Control': 'no-cache',
+        'X-Accel-Buffering': 'no',
         Connection: 'keep-alive',
       });
 


### PR DESCRIPTION
This PR adds the [`X-Accel-Buffering`](https://www.nginx.com/resources/wiki/start/topics/examples/x-accel/#x-accel-buffering) header to response of the `swapstatus` REST endpoint. It will fix an error with the NGINX reverse proxy that caused the SSE events to fail after two minutes.