### PR TITLE
fix: amount of BIP21 payment requests

### DIFF
--- a/lib/service/PaymentRequestUtils.ts
+++ b/lib/service/PaymentRequestUtils.ts
@@ -9,7 +9,7 @@ const getBip21Prefix = (symbol: string) => {
  * Encode a BIP21 payment request
  */
 export const encodeBip21 = (symbol: string, address: string, satoshis: number, label?: string) => {
-  let request = `${getBip21Prefix(symbol)}:${address}?value=${satoshis / 100000000}`;
+  let request = `${getBip21Prefix(symbol)}:${address}?amount=${satoshis / 100000000}`;
 
   if (label) {
     request += `&label=${label.replace(/ /g, '%20')}`;


### PR DESCRIPTION
I made a mistake and encoded the amounts of the BIP21 payment requests incorrectly. This PR fixes that error.