### PR TITLE
fix: set timeout block number of swaps

### DIFF
--- a/lib/boltz/BoltzClient.ts
+++ b/lib/boltz/BoltzClient.ts
@@ -213,11 +213,12 @@ class BoltzClient extends BaseClient {
 
     const request = new boltzrpc.CreateSwapRequest();
 
-    request.setBaseCurrency(baseCurrency);
-    request.setQuoteCurrency(quoteCurrency);
-    request.setOrderSide(orderSide);
     request.setRate(rate);
     request.setInvoice(invoice);
+    request.setOrderSide(orderSide);
+    request.setTimeoutBlockNumber(10);
+    request.setBaseCurrency(baseCurrency);
+    request.setQuoteCurrency(quoteCurrency);
     request.setRefundPublicKey(refundPublicKey);
 
     if (outputType) {
@@ -235,12 +236,13 @@ class BoltzClient extends BaseClient {
 
     const request = new boltzrpc.CreateReverseSwapRequest();
 
+    request.setRate(rate);
+    request.setAmount(amount);
+    request.setOrderSide(orderSide);
+    request.setTimeoutBlockNumber(10);
     request.setBaseCurrency(baseCurrency);
     request.setQuoteCurrency(quoteCurrency);
-    request.setOrderSide(orderSide);
-    request.setRate(rate);
     request.setClaimPublicKey(claimPublicKey);
-    request.setAmount(amount);
 
     return this.unaryCall<boltzrpc.CreateReverseSwapRequest, boltzrpc.CreateReverseSwapResponse.AsObject>('createReverseSwap', request);
   }

--- a/lib/proto/boltzrpc_pb.d.ts
+++ b/lib/proto/boltzrpc_pb.d.ts
@@ -577,6 +577,9 @@ export class CreateSwapRequest extends jspb.Message {
     getOutputType(): OutputType;
     setOutputType(value: OutputType): void;
 
+    getTimeoutBlockNumber(): number;
+    setTimeoutBlockNumber(value: number): void;
+
 
     serializeBinary(): Uint8Array;
     toObject(includeInstance?: boolean): CreateSwapRequest.AsObject;
@@ -597,6 +600,7 @@ export namespace CreateSwapRequest {
         invoice: string,
         refundPublicKey: string,
         outputType: OutputType,
+        timeoutBlockNumber: number,
     }
 }
 
@@ -652,6 +656,9 @@ export class CreateReverseSwapRequest extends jspb.Message {
     getAmount(): number;
     setAmount(value: number): void;
 
+    getTimeoutBlockNumber(): number;
+    setTimeoutBlockNumber(value: number): void;
+
 
     serializeBinary(): Uint8Array;
     toObject(includeInstance?: boolean): CreateReverseSwapRequest.AsObject;
@@ -671,6 +678,7 @@ export namespace CreateReverseSwapRequest {
         rate: number,
         claimPublicKey: string,
         amount: number,
+        timeoutBlockNumber: number,
     }
 }
 

--- a/lib/proto/boltzrpc_pb.js
+++ b/lib/proto/boltzrpc_pb.js
@@ -3805,7 +3805,8 @@ proto.boltzrpc.CreateSwapRequest.toObject = function(includeInstance, msg) {
     rate: +jspb.Message.getFieldWithDefault(msg, 4, 0.0),
     invoice: jspb.Message.getFieldWithDefault(msg, 5, ""),
     refundPublicKey: jspb.Message.getFieldWithDefault(msg, 6, ""),
-    outputType: jspb.Message.getFieldWithDefault(msg, 7, 0)
+    outputType: jspb.Message.getFieldWithDefault(msg, 7, 0),
+    timeoutBlockNumber: jspb.Message.getFieldWithDefault(msg, 8, 0)
   };
 
   if (includeInstance) {
@@ -3869,6 +3870,10 @@ proto.boltzrpc.CreateSwapRequest.deserializeBinaryFromReader = function(msg, rea
     case 7:
       var value = /** @type {!proto.boltzrpc.OutputType} */ (reader.readEnum());
       msg.setOutputType(value);
+      break;
+    case 8:
+      var value = /** @type {number} */ (reader.readInt64());
+      msg.setTimeoutBlockNumber(value);
       break;
     default:
       reader.skipField();
@@ -3945,6 +3950,13 @@ proto.boltzrpc.CreateSwapRequest.serializeBinaryToWriter = function(message, wri
   if (f !== 0.0) {
     writer.writeEnum(
       7,
+      f
+    );
+  }
+  f = message.getTimeoutBlockNumber();
+  if (f !== 0) {
+    writer.writeInt64(
+      8,
       f
     );
   }
@@ -4053,6 +4065,21 @@ proto.boltzrpc.CreateSwapRequest.prototype.getOutputType = function() {
 /** @param {!proto.boltzrpc.OutputType} value */
 proto.boltzrpc.CreateSwapRequest.prototype.setOutputType = function(value) {
   jspb.Message.setField(this, 7, value);
+};
+
+
+/**
+ * optional int64 timeout_block_number = 8;
+ * @return {number}
+ */
+proto.boltzrpc.CreateSwapRequest.prototype.getTimeoutBlockNumber = function() {
+  return /** @type {number} */ (jspb.Message.getFieldWithDefault(this, 8, 0));
+};
+
+
+/** @param {number} value */
+proto.boltzrpc.CreateSwapRequest.prototype.setTimeoutBlockNumber = function(value) {
+  jspb.Message.setField(this, 8, value);
 };
 
 
@@ -4331,7 +4358,8 @@ proto.boltzrpc.CreateReverseSwapRequest.toObject = function(includeInstance, msg
     orderSide: jspb.Message.getFieldWithDefault(msg, 3, 0),
     rate: +jspb.Message.getFieldWithDefault(msg, 4, 0.0),
     claimPublicKey: jspb.Message.getFieldWithDefault(msg, 5, ""),
-    amount: jspb.Message.getFieldWithDefault(msg, 6, 0)
+    amount: jspb.Message.getFieldWithDefault(msg, 6, 0),
+    timeoutBlockNumber: jspb.Message.getFieldWithDefault(msg, 7, 0)
   };
 
   if (includeInstance) {
@@ -4391,6 +4419,10 @@ proto.boltzrpc.CreateReverseSwapRequest.deserializeBinaryFromReader = function(m
     case 6:
       var value = /** @type {number} */ (reader.readInt64());
       msg.setAmount(value);
+      break;
+    case 7:
+      var value = /** @type {number} */ (reader.readInt64());
+      msg.setTimeoutBlockNumber(value);
       break;
     default:
       reader.skipField();
@@ -4460,6 +4492,13 @@ proto.boltzrpc.CreateReverseSwapRequest.serializeBinaryToWriter = function(messa
   if (f !== 0) {
     writer.writeInt64(
       6,
+      f
+    );
+  }
+  f = message.getTimeoutBlockNumber();
+  if (f !== 0) {
+    writer.writeInt64(
+      7,
       f
     );
   }
@@ -4553,6 +4592,21 @@ proto.boltzrpc.CreateReverseSwapRequest.prototype.getAmount = function() {
 /** @param {number} value */
 proto.boltzrpc.CreateReverseSwapRequest.prototype.setAmount = function(value) {
   jspb.Message.setField(this, 6, value);
+};
+
+
+/**
+ * optional int64 timeout_block_number = 7;
+ * @return {number}
+ */
+proto.boltzrpc.CreateReverseSwapRequest.prototype.getTimeoutBlockNumber = function() {
+  return /** @type {number} */ (jspb.Message.getFieldWithDefault(this, 7, 0));
+};
+
+
+/** @param {number} value */
+proto.boltzrpc.CreateReverseSwapRequest.prototype.setTimeoutBlockNumber = function(value) {
+  jspb.Message.setField(this, 7, value);
 };
 
 

--- a/lib/service/Service.ts
+++ b/lib/service/Service.ts
@@ -219,7 +219,7 @@ class Service extends EventEmitter {
       redeemScript,
       expectedAmount,
       timeoutBlockHeight,
-    } = await this.boltz.createSwap(base, quote, side, rate, invoice, refundPublicKey, OutputType.COMPATIBILITY);
+    } = await this.boltz.createSwap(base, quote, side, rate, invoice, refundPublicKey, OutputType.BECH32);
     await this.boltz.listenOnAddress(chainCurrency, address);
 
     const id = generateId(6);

--- a/proto/boltzrpc.proto
+++ b/proto/boltzrpc.proto
@@ -151,6 +151,7 @@ message CreateSwapRequest {
   string invoice = 5;
   string refund_public_key = 6;
   OutputType output_type = 7;
+  int64 timeout_block_number = 8;
 }
 message CreateSwapResponse {
   string redeem_script = 1;
@@ -167,6 +168,7 @@ message CreateReverseSwapRequest {
   string claim_public_key = 5;
   // Amount of the invoice that will be returned
   int64 amount = 6;
+  int64 timeout_block_number = 7;
 }
 message CreateReverseSwapResponse {
   string invoice = 1;


### PR DESCRIPTION
This PR:

- sets the `timeout_block_number` of normal and reverse swaps to 10 because if it isn't set at all the timeout will be 0
- sets the output type of swaps to `BECH32`