### PR TITLE
chore: switch back to compatibility addresses

### DIFF
--- a/lib/service/Service.ts
+++ b/lib/service/Service.ts
@@ -219,7 +219,7 @@ class Service extends EventEmitter {
       redeemScript,
       expectedAmount,
       timeoutBlockHeight,
-    } = await this.boltz.createSwap(base, quote, side, rate, invoice, refundPublicKey, OutputType.BECH32);
+    } = await this.boltz.createSwap(base, quote, side, rate, invoice, refundPublicKey, OutputType.COMPATIBILITY);
     await this.boltz.listenOnAddress(chainCurrency, address);
 
     const id = generateId(6);


### PR DESCRIPTION
#43 set the output type of normal swaps to native SegWit which was a mistake in hindsight because lots of wallets still don't support sending to bech32 addresses :roll_eyes: 

Maybe we should offer the user the possibility to decide whether they want to get a compatibility or native SegWit address but for now we should stick to compatibility addresses for the sake of supporting *all wallets*.