### PR TITLE
fix: error when message is sent to a Slack thread

### DIFF
--- a/lib/notifications/SlackClient.ts
+++ b/lib/notifications/SlackClient.ts
@@ -54,7 +54,9 @@ class SlackClient extends EventEmitter {
 
     this.rtm.on('message', (message: Message) => {
       if (message.channel === this.channelId) {
-        this.emit('message', message.text);
+        if (message.text) {
+          this.emit('message', message.text);
+        }
       }
     });
   }


### PR DESCRIPTION
The middleware throws an error if a message gets sent to a Slack thread because the `text` property of the incoming message object is `undefined`. This PR adds a simple check for whether `text` is defined.

```
Feb 21 09:28:11 boltz-mainnet boltzm[19106]: (node:19106) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'toLowerCase' of undefined
Feb 21 09:28:11 boltz-mainnet boltzm[19106]:     at NotificationProvider.<anonymous> (/home/boltz/boltz-middleware/dist/notifications/NotificationProvider.js:121:33)
Feb 21 09:28:11 boltz-mainnet boltzm[19106]:     at Generator.next (<anonymous>)
Feb 21 09:28:11 boltz-mainnet boltzm[19106]:     at /home/boltz/boltz-middleware/dist/notifications/NotificationProvider.js:7:71
Feb 21 09:28:11 boltz-mainnet boltzm[19106]:     at new Promise (<anonymous>)
Feb 21 09:28:11 boltz-mainnet boltzm[19106]:     at __awaiter (/home/boltz/boltz-middleware/dist/notifications/NotificationProvider.js:3:12)
Feb 21 09:28:11 boltz-mainnet boltzm[19106]:     at SlackClient.slack.on (/home/boltz/boltz-middleware/dist/notifications/NotificationProvider.js:120:51)
Feb 21 09:28:11 boltz-mainnet boltzm[19106]:     at SlackClient.emit (events.js:189:13)
Feb 21 09:28:11 boltz-mainnet boltzm[19106]:     at RTMClient.rtm.on (/home/boltz/boltz-middleware/dist/notifications/SlackClient.js:35:26)
Feb 21 09:28:11 boltz-mainnet boltzm[19106]:     at RTMClient.emit (/home/boltz/boltz-middleware/node_modules/eventemitter3/index.js:181:35)
Feb 21 09:28:11 boltz-mainnet boltzm[19106]:     at RTMClient.onWebsocketMessage (/home/boltz/boltz-middleware/node_modules/@slack/client/dist/RTMClient.js:475:14)
Feb 21 09:28:11 boltz-mainnet boltzm[19106]:     at WebSocket.onMessage (/home/boltz/boltz-middleware/node_modules/ws/lib/event-target.js:120:16)
Feb 21 09:28:11 boltz-mainnet boltzm[19106]:     at WebSocket.emit (events.js:189:13)
Feb 21 09:28:11 boltz-mainnet boltzm[19106]:     at Receiver.receiverOnMessage (/home/boltz/boltz-middleware/node_modules/ws/lib/websocket.js:720:20)
Feb 21 09:28:11 boltz-mainnet boltzm[19106]:     at Receiver.emit (events.js:189:13)
Feb 21 09:28:11 boltz-mainnet boltzm[19106]:     at Receiver.dataMessage (/home/boltz/boltz-middleware/node_modules/ws/lib/receiver.js:414:14)
Feb 21 09:28:11 boltz-mainnet boltzm[19106]:     at Receiver.getData (/home/boltz/boltz-middleware/node_modules/ws/lib/receiver.js:346:17)
Feb 21 09:28:11 boltz-mainnet boltzm[19106]:     at Receiver.startLoop (/home/boltz/boltz-middleware/node_modules/ws/lib/receiver.js:133:22)
Feb 21 09:28:11 boltz-mainnet boltzm[19106]:     at Receiver._write (/home/boltz/boltz-middleware/node_modules/ws/lib/receiver.js:69:10)
Feb 21 09:28:11 boltz-mainnet boltzm[19106]:     at doWrite (_stream_writable.js:410:12)
Feb 21 09:28:11 boltz-mainnet boltzm[19106]:     at writeOrBuffer (_stream_writable.js:394:5)
Feb 21 09:28:11 boltz-mainnet boltzm[19106]:     at Receiver.Writable.write (_stream_writable.js:294:11)
Feb 21 09:28:11 boltz-mainnet boltzm[19106]:     at TLSSocket.socketOnData (/home/boltz/boltz-middleware/node_modules/ws/lib/websocket.js:795:35)
```