### PR TITLE
fix: time out of event stream after 2 minutes

### DIFF
--- a/lib/api/Controller.ts
+++ b/lib/api/Controller.ts
@@ -137,6 +137,8 @@ class Controller {
         Connection: 'keep-alive',
       });
 
+      res.setTimeout(0);
+
       this.pendingSwaps.set(id, res);
 
       res.on('close', () => {


### PR DESCRIPTION
By default a Node.js HTTP server terminates a request after two minutes. This PR sets the timeout of requests for the event stream to `0` which means that the request won't terminate until the user finished the swap or closes the window.