### PR TITLE
 feat: add InvoiceFailedToPay event to swap status

### DIFF
--- a/lib/proto/boltzrpc_grpc_pb.js
+++ b/lib/proto/boltzrpc_grpc_pb.js
@@ -388,7 +388,7 @@ var BoltzService = exports.BoltzService = {
     responseSerialize: serialize_boltzrpc_SubscribeTransactionsResponse,
     responseDeserialize: deserialize_boltzrpc_SubscribeTransactionsResponse,
   },
-  // Subscribes to a stream of settled invoices and those paid by Boltz 
+  // Subscribes to a stream of invoice events 
   subscribeInvoices: {
     path: '/boltzrpc.Boltz/SubscribeInvoices',
     requestStream: false,

--- a/lib/proto/boltzrpc_pb.d.ts
+++ b/lib/proto/boltzrpc_pb.d.ts
@@ -880,5 +880,6 @@ export enum OrderSide {
 
 export enum InvoiceEvent {
     PAID = 0,
-    SETTLED = 1,
+    FAILED_TO_PAY = 1,
+    SETTLED = 2,
 }

--- a/lib/proto/boltzrpc_pb.js
+++ b/lib/proto/boltzrpc_pb.js
@@ -5852,7 +5852,8 @@ proto.boltzrpc.OrderSide = {
  */
 proto.boltzrpc.InvoiceEvent = {
   PAID: 0,
-  SETTLED: 1
+  FAILED_TO_PAY: 1,
+  SETTLED: 2
 };
 
 goog.object.extend(exports, proto.boltzrpc);

--- a/package-lock.json
+++ b/package-lock.json
@@ -148,9 +148,9 @@
       "integrity": "sha512-Xqg/lIZMrUd0VRmSRbCAewtwGZiAk3mEUDvV4op1tGl+LvyPcb/MIOSxTl9z+9+J+R4/vpjiCAT4xeKzH9ji1w=="
     },
     "@types/lodash": {
-      "version": "4.14.121",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.121.tgz",
-      "integrity": "sha512-ORj7IBWj13iYufXt/VXrCNMbUuCTJfhzme5kx9U/UtcIPdJYuvPDUAlHlbNhz/8lKCLy9XGIZnGrqXOtQbPGoQ==",
+      "version": "4.14.122",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.122.tgz",
+      "integrity": "sha512-9IdED8wU93ty8gP06ninox+42SBSJHp2IAamsSYMUY76mshRTeUsid/gtbl8ovnOwy8im41ib4cxTiIYMXGKew==",
       "dev": true
     },
     "@types/mime": {
@@ -166,9 +166,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "10.12.27",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.27.tgz",
-      "integrity": "sha512-e9wgeY6gaY21on3ve0xAjgBVjGDWq/xUteK0ujsE53bUoxycMkqfnkUgMt6ffZtykZ5X12Mg3T7Pw4TRCObDKg=="
+      "version": "10.12.30",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.30.tgz",
+      "integrity": "sha512-nsqTN6zUcm9xtdJiM9OvOJ5EF0kOI8f1Zuug27O/rgtxCRJHGqncSWfCMZUP852dCKPsDsYXGvBhxfRjDBkF5Q=="
     },
     "@types/range-parser": {
       "version": "1.2.3",
@@ -177,9 +177,9 @@
       "dev": true
     },
     "@types/sequelize": {
-      "version": "4.27.38",
-      "resolved": "https://registry.npmjs.org/@types/sequelize/-/sequelize-4.27.38.tgz",
-      "integrity": "sha512-HR+epHzmU8xSMRUjhuuYKHn3IxD2Ft4OePEqXY8/6otDyPn9s6SZx4bVLnUa98jv6Ny0Di9IHQHOXh35O7QajQ==",
+      "version": "4.27.39",
+      "resolved": "https://registry.npmjs.org/@types/sequelize/-/sequelize-4.27.39.tgz",
+      "integrity": "sha512-FABh5gLbXgh6/0pmJQ7VzjN5KAxd/IbX3G5Z6fSBZ6DSqaYl7DBP22nGtLh2e6dPmC0rUxfJclNhzQcC3XgvVw==",
       "dev": true,
       "requires": {
         "@types/bluebird": "*",
@@ -2839,9 +2839,9 @@
       }
     },
     "generic-pool": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.6.1.tgz",
-      "integrity": "sha512-iMmD/pY4q0+V+f8o4twE9JPeqfNuX+gJAaIPB3B0W1lFkBOtTxBo6B0HxHPgGhzQA8jego7EWopcYq/UDJO2KA=="
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.5.0.tgz",
+      "integrity": "sha512-dEkxmX+egB2o4NR80c/q+xzLLzLX+k68/K8xv81XprD+Sk7ZtP14VugeCz+fUwv5FzpWq40pPtAkzPRqT8ka9w=="
     },
     "get-caller-file": {
       "version": "1.0.3",
@@ -3001,9 +3001,9 @@
       "dev": true
     },
     "grpc": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/grpc/-/grpc-1.18.0.tgz",
-      "integrity": "sha512-M0K67Zhv2ZzCjrTbQvjWgYFPB929L+qAVnbNgXepbfO5kJxUYc30dP8m8vb+o8QdahLHAeYfIqRoIzZRcCB98Q==",
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/grpc/-/grpc-1.19.0.tgz",
+      "integrity": "sha512-xX+jZ1M3YXjngsRj/gTxB4EwM0WoWUr54DmyNq9xTeg1oSuVaTPD/PK9wnZKOJWTt1pkeFspXqwJPhddZNxHOA==",
       "requires": {
         "lodash.camelcase": "^4.3.0",
         "lodash.clone": "^4.5.0",
@@ -5998,16 +5998,16 @@
       }
     },
     "sequelize": {
-      "version": "4.42.0",
-      "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-4.42.0.tgz",
-      "integrity": "sha512-qxAYnX4rcv7PbNtEidb56REpxNJCdbN0qyk1jb3+e6sE7OrmS0nYMU+MFVbNTJtZfSpOEEL1TX0TkMw+wzZBxg==",
+      "version": "4.43.0",
+      "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-4.43.0.tgz",
+      "integrity": "sha512-GkwGFVREKBf/ql6W6RXwXy1fzb/HOk0lmOBbcQrJMvJtB65Jfg7CUh+sENh0deuWk5s79JedgZJ/yEjvtzHXaQ==",
       "requires": {
         "bluebird": "^3.5.0",
         "cls-bluebird": "^2.1.0",
         "debug": "^3.1.0",
         "depd": "^1.1.0",
         "dottie": "^2.0.0",
-        "generic-pool": "^3.4.0",
+        "generic-pool": "3.5.0",
         "inflection": "1.12.0",
         "lodash": "^4.17.1",
         "moment": "^2.20.0",
@@ -6736,9 +6736,9 @@
       "dev": true
     },
     "tslint": {
-      "version": "5.13.0",
-      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.13.0.tgz",
-      "integrity": "sha512-ECOOQRxXCYnUUePG5h/+Z1Zouobk3KFpIHA9aKBB/nnMxs97S1JJPDGt5J4cGm1y9U9VmVlfboOxA8n1kSNzGw==",
+      "version": "5.13.1",
+      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.13.1.tgz",
+      "integrity": "sha512-fplQqb2miLbcPhyHoMV4FU9PtNRbgmm/zI5d3SZwwmJQM6V0eodju+hplpyfhLWpmwrDNfNYU57uYRb8s0zZoQ==",
       "dev": true,
       "requires": {
         "babel-code-frame": "^6.22.0",
@@ -6827,9 +6827,9 @@
       }
     },
     "tslint-no-circular-imports": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/tslint-no-circular-imports/-/tslint-no-circular-imports-0.6.1.tgz",
-      "integrity": "sha512-XuRgHZKFu6dv7fm/tuilmvynLHgtCTd63/p3744dYVEpnMExp2Jd9IwTiBOGmy5bUDlpTy117vtBcLd028RsBA==",
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/tslint-no-circular-imports/-/tslint-no-circular-imports-0.6.2.tgz",
+      "integrity": "sha512-WtOE8ArVcZzFDw62Ya/tzk0VeB4xLh4V0Eft2jxKHqUpDzz2S6J63AnhQv3YVyChaj7G4tBhPBE0tcVAflsw4A==",
       "dev": true
     },
     "tsutils": {
@@ -7266,13 +7266,6 @@
       "integrity": "sha512-LHxXlzRCYQXA9ZHgs8r7Gafh0gVOE8o3QmudM1PIkOdkXXjW7Thcl+gb2P2dRuKgW8cqkitCRZkkjtmWzpHi7A==",
       "requires": {
         "@types/node": "*"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "11.9.4",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-11.9.4.tgz",
-          "integrity": "sha512-Zl8dGvAcEmadgs1tmSPcvwzO1YRsz38bVJQvH1RvRqSR9/5n61Q1ktcDL0ht3FXWR+ZpVmXVwN1LuH4Ax23NsA=="
-        }
       }
     },
     "wordwrap": {

--- a/package.json
+++ b/package.json
@@ -52,8 +52,8 @@
     "cross-os": "^1.3.0",
     "discord.js": "^11.4.2",
     "express": "^4.16.4",
-    "grpc": "^1.18.0",
-    "sequelize": "^4.42.0",
+    "grpc": "^1.19.0",
+    "sequelize": "^4.43.0",
     "sqlite3": "^4.0.6",
     "toml": "^2.3.6",
     "winston": "^3.2.1",
@@ -65,8 +65,8 @@
     "@types/cors": "^2.8.4",
     "@types/express": "^4.16.1",
     "@types/mocha": "^5.2.5",
-    "@types/node": "^10.12.27",
-    "@types/sequelize": "^4.27.38",
+    "@types/node": "^10.12.30",
+    "@types/sequelize": "^4.27.39",
     "@types/yargs": "^12.0.8",
     "chai": "^4.2.0",
     "concurrently": "^4.1.0",
@@ -75,9 +75,9 @@
     "mocha": "^5.2.0",
     "nodemon": "^1.18.10",
     "ts-node": "^7.0.1",
-    "tslint": "^5.13.0",
+    "tslint": "^5.13.1",
     "tslint-config-airbnb": "^5.11.1",
-    "tslint-no-circular-imports": "^0.6.1",
+    "tslint-no-circular-imports": "^0.6.2",
     "typescript": "^3.3.3333"
   }
 }

--- a/proto/boltzrpc.proto
+++ b/proto/boltzrpc.proto
@@ -27,7 +27,7 @@ service Boltz {
   /* Subscribes to a stream of confirmed transactions to addresses that were specified with "ListenOnAddress" */
   rpc SubscribeTransactions (SubscribeTransactionsRequest) returns (stream SubscribeTransactionsResponse);
 
-  /* Subscribes to a stream of settled invoices and those paid by Boltz */
+  /* Subscribes to a stream of invoice events */
   rpc SubscribeInvoices (SubscribeInvoicesRequest) returns (stream SubscribeInvoicesResponse);
 
   /* Subscribes to a stream of lockup transactions that Boltz refunds */
@@ -56,7 +56,8 @@ enum OrderSide {
 
 enum InvoiceEvent {
   PAID = 0;
-  SETTLED = 1;
+  FAILED_TO_PAY = 1;
+  SETTLED = 2;
 }
 
 message GetInfoRequest {}


### PR DESCRIPTION
Depends on https://github.com/BoltzExchange/boltz-backend/pull/93

In this PR I:
- added a new event to the stream for normal swaps: `invoice.failedToPay`
- restructured the messages in the stream to make parsing them in the frontend easier