### PR TITLE
feat: save swap information in database

### DIFF
--- a/lib/BoltzMiddleware.ts
+++ b/lib/BoltzMiddleware.ts
@@ -55,7 +55,7 @@ class BoltzMiddleware {
     await this.service.init(this.config.pairs);
     await this.notifications.init();
 
-    this.api.init();
+    await this.api.init();
   }
 }
 

--- a/lib/api/Api.ts
+++ b/lib/api/Api.ts
@@ -13,6 +13,7 @@ type ApiConfig = {
 
 class Api {
   private app: Application;
+  private controller: Controller;
 
   constructor(private logger: Logger, private config: ApiConfig, service: Service) {
     this.app = express();
@@ -20,11 +21,13 @@ class Api {
     this.app.use(cors());
     this.app.use(express.json());
 
-    const controller = new Controller(logger, service);
-    this.registerRoutes(controller);
+    this.controller = new Controller(logger, service);
+    this.registerRoutes(this.controller);
   }
 
-  public init = () => {
+  public init = async () => {
+    await this.controller.init();
+
     this.app.listen(this.config.port, this.config.host, () => {
       this.logger.info(`API server listening on: ${this.config.host}:${this.config.port}`);
     });

--- a/lib/boltz/BoltzClient.ts
+++ b/lib/boltz/BoltzClient.ts
@@ -228,7 +228,7 @@ class BoltzClient extends BaseClient {
 
     this.transactionSubscription = this.boltz.subscribeTransactions(new boltzrpc.SubscribeTransactionsRequest(), this.meta)
       .on('data', (response: boltzrpc.SubscribeTransactionsResponse) => {
-        this.logger.silly(`Found transaction to address ${response.getOutputAddress()} confirmed: ${response.getTransactionHash()}`);
+        this.logger.debug(`Found transaction to address ${response.getOutputAddress()} confirmed: ${response.getTransactionHash()}`);
         this.emit('transaction.confirmed', response.getTransactionHash(), response.getOutputAddress());
       })
       .on('error', async (error) => {
@@ -253,19 +253,19 @@ class BoltzClient extends BaseClient {
 
         switch (response.getEvent()) {
           case boltzrpc.InvoiceEvent.PAID:
-            this.logger.silly(`Invoice paid: ${invoice}`);
+            this.logger.debug(`Invoice paid: ${invoice}`);
             this.emit('invoice.paid', invoice);
 
             break;
 
           case boltzrpc.InvoiceEvent.FAILED_TO_PAY:
-            this.logger.silly(`Failed to pay invoice: ${invoice}`);
+            this.logger.debug(`Failed to pay invoice: ${invoice}`);
             this.emit('invoice.failedToPay', invoice);
 
             break;
 
           case boltzrpc.InvoiceEvent.SETTLED:
-            this.logger.silly(`Invoice settled: ${invoice}`);
+            this.logger.debug(`Invoice settled: ${invoice}`);
             this.emit('invoice.settled', invoice, response.getPreimage());
 
             break;
@@ -290,7 +290,7 @@ class BoltzClient extends BaseClient {
     this.refundsSubscription = this.boltz.subscribeRefunds(new boltzrpc.SubscribeRefundsRequest(), this.meta)
       .on('data', (response: boltzrpc.SubscribeRefundsResponse) => {
         const lockupTransactionHash = response.getLockupTransactionHash();
-        this.logger.silly(`Refunded lockup transaction: ${lockupTransactionHash}`);
+        this.logger.debug(`Refunded lockup transaction: ${lockupTransactionHash}`);
         this.emit('refund', lockupTransactionHash);
       })
       .on('error', async (error) => {

--- a/lib/consts/Database.ts
+++ b/lib/consts/Database.ts
@@ -25,3 +25,27 @@ export type PairAttributes = PairFactory & {
 };
 
 export type PairInstance = PairAttributes & Sequelize.Instance<PairAttributes>;
+
+type Swap = {
+  id: string;
+  pair: string;
+  status?: string;
+  invoice: string;
+};
+
+export type SwapFactory = Swap & {
+  lockupAddress: string;
+};
+
+export type SwapAttributes = SwapFactory;
+
+export type SwapInstance = SwapFactory & Sequelize.Instance<SwapAttributes>;
+
+export type ReverseSwapFactory = Swap & {
+  preimage?: string;
+  transactionId: string;
+};
+
+export type ReverseSwapAttributes = ReverseSwapFactory;
+
+export type ReverseSwapInstance = ReverseSwapFactory & Sequelize.Instance<ReverseSwapAttributes>;

--- a/lib/consts/Types.ts
+++ b/lib/consts/Types.ts
@@ -1,4 +1,12 @@
+import { SwapUpdateEvent } from './Enums';
+
 export type Error = {
   message: string;
   code: string;
+};
+
+export type SwapUpdate = {
+  event: SwapUpdateEvent,
+
+  preimage?: string;
 };

--- a/lib/db/Database.ts
+++ b/lib/db/Database.ts
@@ -1,11 +1,13 @@
 import fs from 'fs';
 import path from 'path';
 import Sequelize from 'sequelize';
-import * as db from '../consts/Database';
 import Logger from '../Logger';
+import * as db from '../consts/Database';
 
 type Models = {
   Pair: Sequelize.Model<db.PairInstance, db.PairAttributes>;
+  Swap: Sequelize.Model<db.SwapInstance, db.SwapAttributes>;
+  ReverseSwap: Sequelize.Model<db.ReverseSwapInstance, db.ReverseSwapAttributes>;
 };
 
 class Database {
@@ -35,8 +37,11 @@ class Database {
       throw error;
     }
 
+    await this.models.Pair.sync(),
+
     await Promise.all([
-      this.models.Pair.sync(),
+      this.models.Swap.sync(),
+      this.models.ReverseSwap.sync(),
     ]);
   }
 

--- a/lib/db/models/Pair.ts
+++ b/lib/db/models/Pair.ts
@@ -1,6 +1,6 @@
 import Sequelize from 'sequelize';
-import * as db from '../../consts/Database';
 import { getPairId } from '../../Utils';
+import * as db from '../../consts/Database';
 
 export default (sequelize: Sequelize.Sequelize, dataTypes: Sequelize.DataTypes) => {
   const attributes: db.SequelizeAttributes<db.PairAttributes> = {

--- a/lib/db/models/ReverseSwap.ts
+++ b/lib/db/models/ReverseSwap.ts
@@ -1,0 +1,27 @@
+import Sequelize from 'sequelize';
+import * as db from '../../consts/Database';
+
+export default (sequelize: Sequelize.Sequelize, dataTypes: Sequelize.DataTypes) => {
+  const attributes: db.SequelizeAttributes<db.ReverseSwapAttributes> = {
+    id: { type: dataTypes.STRING, primaryKey: true, allowNull: false },
+    pair: { type: dataTypes.STRING, allowNull: false },
+    status: { type: dataTypes.STRING, allowNull: true },
+    invoice: { type: dataTypes.STRING, allowNull: false },
+    preimage: { type: dataTypes.STRING, allowNull: true },
+    transactionId: { type: dataTypes.STRING, allowNull: false },
+  };
+
+  const options: Sequelize.DefineOptions<db.ReverseSwapInstance> = {
+    tableName: 'reverseSwaps',
+  };
+
+  const ReverseSwap = sequelize.define<db.ReverseSwapInstance, db.ReverseSwapAttributes>('ReverseSwap', attributes, options);
+
+  ReverseSwap.associate = (models: Sequelize.Models) => {
+    models.ReverseSwap.belongsTo(models.Pair, {
+      foreignKey: 'pair',
+    });
+  };
+
+  return ReverseSwap;
+};

--- a/lib/db/models/Swap.ts
+++ b/lib/db/models/Swap.ts
@@ -1,0 +1,32 @@
+import Sequelize from 'sequelize';
+import * as db from '../../consts/Database';
+
+export default (sequelize: Sequelize.Sequelize, dataTypes: Sequelize.DataTypes) => {
+  const attributes: db.SequelizeAttributes<db.SwapAttributes> = {
+    id: { type: dataTypes.STRING, primaryKey: true, allowNull: false },
+    pair: { type: dataTypes.STRING, allowNull: false },
+    status: { type: dataTypes.STRING, allowNull: true },
+    invoice: { type: dataTypes.STRING, unique: true, allowNull: false },
+    lockupAddress: { type: dataTypes.STRING, allowNull: false },
+  };
+
+  const options: Sequelize.DefineOptions<db.SwapInstance> = {
+    tableName: 'swaps',
+    indexes: [
+      {
+        unique: true,
+        fields: ['id', 'invoice'],
+      },
+    ],
+  };
+
+  const Swap = sequelize.define<db.SwapInstance, db.SwapAttributes>('Swap', attributes, options);
+
+  Swap.associate = (models: Sequelize.Models) => {
+    models.Swap.belongsTo(models.Pair, {
+      foreignKey: 'pair',
+    });
+  };
+
+  return Swap;
+};

--- a/lib/service/Errors.ts
+++ b/lib/service/Errors.ts
@@ -23,4 +23,8 @@ export default {
     message: `${amount} is less than minimal ${minimalAmount}`,
     code: concatErrorCode(ErrorCodePrefix.Service, 4),
   }),
+  SWAP_WITH_INVOICE_EXISTS_ALREADY: (invoice: string): Error => ({
+    message: `a swap with the invoice ${invoice} exists already`,
+    code: concatErrorCode(ErrorCodePrefix.Service, 5),
+  }),
 };

--- a/lib/service/ReverseSwapRepository.ts
+++ b/lib/service/ReverseSwapRepository.ts
@@ -1,0 +1,33 @@
+import { WhereOptions } from 'sequelize';
+import { Models } from '../db/Database';
+import * as db from '../consts/Database';
+
+class ReverseSwapRepository {
+  constructor(private models: Models) {}
+
+  public getReverseSwaps = async () => {
+    return this.models.ReverseSwap.findAll({});
+  }
+
+  public getReverseSwap = async (options: WhereOptions<db.ReverseSwapFactory>) => {
+    return this.models.ReverseSwap.findOne({
+      where: options,
+    });
+  }
+
+  public addReverseSwap = async (reverseSwap: db.ReverseSwapFactory) => {
+    return this.models.ReverseSwap.create(reverseSwap);
+  }
+
+  public setReverseSwapStatus = async (reverseSwap: db.ReverseSwapInstance, status: string) => {
+    return reverseSwap.update({
+      status,
+    });
+  }
+
+  public updateReverseSwap = async (reverseSwap: db.ReverseSwapInstance, keys: object) => {
+    return reverseSwap.update(keys);
+  }
+}
+
+export default ReverseSwapRepository;

--- a/lib/service/SwapRepository.ts
+++ b/lib/service/SwapRepository.ts
@@ -1,0 +1,29 @@
+import { WhereOptions } from 'sequelize';
+import { Models } from '../db/Database';
+import * as db from '../consts/Database';
+
+class SwapRepository {
+  constructor(private models: Models) {}
+
+  public getSwaps = async () => {
+    return this.models.Swap.findAll({});
+  }
+
+  public getSwap = async (options: WhereOptions<db.SwapFactory>) => {
+    return this.models.Swap.findOne({
+      where: options,
+    });
+  }
+
+  public addSwap = async (swap: db.SwapFactory) => {
+    return this.models.Swap.create(swap);
+  }
+
+  public setSwapStatus = async (swap: db.SwapInstance, status: string) => {
+    return swap.update({
+      status,
+    });
+  }
+}
+
+export default SwapRepository;


### PR DESCRIPTION
This PR add the feature of saving all information about a swap in the SQLite database. When the data about the swaps is permanently stored, the latest status update will not be lost which means that a restart of the middleware does not abort all pending swaps.

Still TODO:
- ~[don't override events with ones that are earlier in the flow](https://github.com/BoltzExchange/boltz-middleware/compare/save-pending-swaps?expand=1#diff-656a293cf843469fb25803adc7fee5bfR38) (for example: don't override the `invoice.settled` event with a `transaction.confirmed` one; shouldn't happen in production that a user pays the invoice of a reverse swap before the transaction gets confirmed but we should add a check just make sure that the user always gets the most relevant event)~
- ~add tests~ will be done with the integration tests @ImmanuelSegol is planning