### PR TITLE
feat: add fee column to database

### DIFF
--- a/lib/BoltzMiddleware.ts
+++ b/lib/BoltzMiddleware.ts
@@ -38,6 +38,7 @@ class BoltzMiddleware {
 
     this.notifications = new NotificationProvider(
       this.logger,
+      this.service,
       this.boltzClient,
       this.config.notification,
       this.config.currencies,

--- a/lib/Config.ts
+++ b/lib/Config.ts
@@ -4,9 +4,10 @@ import toml from 'toml';
 import { Arguments } from 'yargs';
 import { ApiConfig } from './api/Api';
 import { PairConfig } from './service/Service';
+import { CurrencyConfig } from './consts/Types';
 import { BoltzConfig } from './boltz/BoltzClient';
 import { getServiceDir, deepMerge, resolveHome } from './Utils';
-import { NotificationConfig, CurrencyConfig } from './notifications/NotificationProvider';
+import { NotificationConfig } from './notifications/NotificationProvider';
 
 class Config {
   public logpath: string;

--- a/lib/Utils.ts
+++ b/lib/Utils.ts
@@ -1,6 +1,7 @@
 import os from 'os';
 import path from 'path';
 import { PairFactory } from './consts/Database';
+import { GetBalanceResponse, Balance, OrderSide } from './proto/boltzrpc_pb';
 
 const idPossibilities = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
 
@@ -160,7 +161,7 @@ export const minutesToMilliseconds = (minutes: number) => {
 /**
  * Convert satoshis to whole coins and remove trailing zeros
  */
-export const satoshisToWholeCoins = (satoshis: number) => {
+export const satoshisToCoins = (satoshis: number) => {
   return roundToDecimals(satoshis / 100000000, 8);
 };
 
@@ -169,4 +170,30 @@ export const satoshisToWholeCoins = (satoshis: number) => {
  */
 export const roundToDecimals = (number: number, decimals: number) => {
   return Number(number.toFixed(decimals));
+};
+
+/**
+ * Converts a "GetBalanceResponse" into a map
+ */
+export const parseBalances = async (balance: GetBalanceResponse.AsObject) => {
+  const balances = new Map<string, Balance.AsObject>();
+
+  balance.balancesMap.forEach(([key, value]) => {
+    balances.set(key, value);
+  });
+
+  return balances;
+};
+
+/**
+ * Gets the symbol for the fee of a swap
+ */
+export const getFeeSymbol = (pairId: string, orderSide: OrderSide, isReverse: boolean): string => {
+  const { base, quote } = splitPairId(pairId);
+
+  if (isReverse) {
+    return orderSide === OrderSide.BUY ? quote : base;
+  } else {
+    return orderSide === OrderSide.BUY ? base : quote;
+  }
 };

--- a/lib/consts/Database.ts
+++ b/lib/consts/Database.ts
@@ -26,9 +26,12 @@ export type PairAttributes = PairFactory & {
 
 export type PairInstance = PairAttributes & Sequelize.Instance<PairAttributes>;
 
-type Swap = {
+export type Swap = {
   id: string;
+  fee: number;
+
   pair: string;
+  orderSide: number;
   status?: string;
   invoice: string;
 };

--- a/lib/consts/Types.ts
+++ b/lib/consts/Types.ts
@@ -10,3 +10,13 @@ export type SwapUpdate = {
 
   preimage?: string;
 };
+
+export type CurrencyConfig = {
+  symbol: string;
+
+  maxSwapAmount: number;
+  minSwapAmount: number;
+
+  minWalletBalance: number;
+  minChannelBalance: number;
+};

--- a/lib/db/models/ReverseSwap.ts
+++ b/lib/db/models/ReverseSwap.ts
@@ -4,7 +4,9 @@ import * as db from '../../consts/Database';
 export default (sequelize: Sequelize.Sequelize, dataTypes: Sequelize.DataTypes) => {
   const attributes: db.SequelizeAttributes<db.ReverseSwapAttributes> = {
     id: { type: dataTypes.STRING, primaryKey: true, allowNull: false },
+    fee: { type: dataTypes.INTEGER, allowNull: false },
     pair: { type: dataTypes.STRING, allowNull: false },
+    orderSide: { type: dataTypes.INTEGER, allowNull: false },
     status: { type: dataTypes.STRING, allowNull: true },
     invoice: { type: dataTypes.STRING, allowNull: false },
     preimage: { type: dataTypes.STRING, allowNull: true },

--- a/lib/db/models/Swap.ts
+++ b/lib/db/models/Swap.ts
@@ -4,7 +4,9 @@ import * as db from '../../consts/Database';
 export default (sequelize: Sequelize.Sequelize, dataTypes: Sequelize.DataTypes) => {
   const attributes: db.SequelizeAttributes<db.SwapAttributes> = {
     id: { type: dataTypes.STRING, primaryKey: true, allowNull: false },
+    fee: { type: dataTypes.INTEGER, allowNull: false },
     pair: { type: dataTypes.STRING, allowNull: false },
+    orderSide: { type: dataTypes.INTEGER, allowNull: false },
     status: { type: dataTypes.STRING, allowNull: true },
     invoice: { type: dataTypes.STRING, unique: true, allowNull: false },
     lockupAddress: { type: dataTypes.STRING, allowNull: false },

--- a/lib/notifications/CommandHandler.ts
+++ b/lib/notifications/CommandHandler.ts
@@ -1,0 +1,89 @@
+import Service from '../service/Service';
+import BoltzClient from '../boltz/BoltzClient';
+import { SwapUpdateEvent } from '../consts/Enums';
+import DiscordClient, { Command } from './DiscordClient';
+import { satoshisToCoins, parseBalances, getFeeSymbol } from '../Utils';
+import { SwapInstance, ReverseSwapInstance, Swap } from '../consts/Database';
+
+class CommandHandler {
+  constructor(
+    private service: Service,
+    private boltz: BoltzClient,
+    private discord: DiscordClient) {
+
+    this.discord.on('command', async (command: Command) => {
+      switch (command) {
+        case Command.GetBalance:
+          await this.sendBalance();
+          break;
+
+        case Command.GetFees:
+          await this.sendFees();
+          break;
+      }
+    });
+  }
+
+  private sendBalance = async () => {
+    const balances = await parseBalances(await this.boltz.getBalance());
+
+    let message = 'Balances:';
+
+    balances.forEach((balance, symbol) => {
+      // tslint:disable-next-line:prefer-template
+      message += `\n\n**${symbol}**\n` +
+        `Wallet: ${satoshisToCoins(balance.walletBalance!.totalBalance)} ${symbol}\n` +
+        `Channels: ${satoshisToCoins(balance.channelBalance)} ${symbol}`;
+    });
+
+    await this.discord.sendMessage(message);
+  }
+
+  private sendFees = async () => {
+    let message = 'Fees:\n';
+
+    // Get all successful (reverse) swaps
+    const [swaps, reverseSwaps] = await Promise.all([
+      this.service.swapRepository.getSwaps({
+        status: SwapUpdateEvent.InvoicePaid,
+      }),
+      this.service.reverseSwapRepository.getReverseSwaps({
+        status: SwapUpdateEvent.InvoiceSettled,
+      }),
+    ]);
+
+    const fees = this.getFeeFromSwaps(swaps, reverseSwaps);
+
+    fees.forEach((fee, symbol) => {
+      message += `\n**${symbol}**: ${satoshisToCoins(fee)} ${symbol}`;
+    });
+
+    await this.discord.sendMessage(message);
+  }
+
+  private getFeeFromSwaps = (swaps: SwapInstance[], reverseSwaps: ReverseSwapInstance[]): Map<string, number> => {
+    // A map between the symbols of the currencies and the fees collected on that chain
+    const fees = new Map<string, number>();
+
+    const getFeeFromSwapMap = (array: Swap[], isReverse: boolean) => {
+      array.forEach((swap) => {
+        const feeSymbol = getFeeSymbol(swap.pair, swap.orderSide, isReverse);
+
+        const fee = fees.get(feeSymbol);
+
+        if (fee) {
+          fees.set(feeSymbol, fee + swap.fee);
+        } else {
+          fees.set(feeSymbol, swap.fee);
+        }
+      });
+    };
+
+    getFeeFromSwapMap(swaps, false);
+    getFeeFromSwapMap(reverseSwaps, true);
+
+    return fees;
+  }
+}
+
+export default CommandHandler;

--- a/lib/notifications/DiscordClient.ts
+++ b/lib/notifications/DiscordClient.ts
@@ -3,6 +3,7 @@ import { Client, TextChannel, Message } from 'discord.js';
 
 enum Command {
   GetBalance,
+  GetFees,
 }
 
 interface DiscordClient {
@@ -25,6 +26,10 @@ class DiscordClient extends EventEmitter {
   }
 
   public init = async () => {
+    if (this.token === '') {
+      throw 'no API token provided';
+    }
+
     await this.client.login(this.token);
 
     const { channels } = this.client;
@@ -66,10 +71,13 @@ class DiscordClient extends EventEmitter {
     }
   }
 
-  private parseMessage = (message: string) => {
+  private parseMessage = (message: string): Command | undefined => {
     switch (message.toLowerCase()) {
       case 'getbalance':
         return Command.GetBalance;
+
+      case 'getfees':
+        return Command.GetFees;
 
       default:
         return undefined;

--- a/lib/notifications/DiscordClient.ts
+++ b/lib/notifications/DiscordClient.ts
@@ -1,14 +1,9 @@
 import { EventEmitter } from 'events';
 import { Client, TextChannel, Message } from 'discord.js';
 
-enum Command {
-  GetBalance,
-  GetFees,
-}
-
 interface DiscordClient {
-  on(event: 'command', listener: (command: Command) => void): this;
-  emit(event: 'command', command: Command): boolean;
+  on(event: 'message', listener: (message: string) => void): this;
+  emit(event: 'message', message: string): boolean;
 }
 
 class DiscordClient extends EventEmitter {
@@ -46,7 +41,7 @@ class DiscordClient extends EventEmitter {
       throw `Could not find Discord channel: ${this.channelName}`;
     }
 
-    await this.listenForCommands();
+    await this.listenForMessages();
   }
 
   public sendMessage = async (message: string) => {
@@ -55,35 +50,17 @@ class DiscordClient extends EventEmitter {
     }
   }
 
-  private listenForCommands = async () => {
+  private listenForMessages = async () => {
     if (this.channel) {
       this.client.on('message', (message: Message) => {
         if (message.author.bot) return;
 
         if (message.channel.id === this.channel!.id) {
-          const command = this.parseMessage(message.content);
-
-          if (command !== undefined) {
-            this.emit('command', command);
-          }
+          this.emit('message', message.content);
         }
       });
-    }
-  }
-
-  private parseMessage = (message: string): Command | undefined => {
-    switch (message.toLowerCase()) {
-      case 'getbalance':
-        return Command.GetBalance;
-
-      case 'getfees':
-        return Command.GetFees;
-
-      default:
-        return undefined;
     }
   }
 }
 
 export default DiscordClient;
-export { Command };

--- a/lib/rates/RateProvider.ts
+++ b/lib/rates/RateProvider.ts
@@ -1,8 +1,8 @@
 import Logger from '../Logger';
 import CryptoCompare from './CryptoCompare';
+import { CurrencyConfig } from '../consts/Types';
 import { PairInstance } from '../consts/Database';
-import { CurrencyConfig } from '../notifications/NotificationProvider';
-import { getPairId, stringify, mapToObject, minutesToMilliseconds, satoshisToWholeCoins, roundToDecimals } from '../Utils';
+import { getPairId, stringify, mapToObject, minutesToMilliseconds, satoshisToCoins, roundToDecimals } from '../Utils';
 
 type Limits = {
   minimal: number;
@@ -136,8 +136,8 @@ class RateProvider {
   private parseCurrencies = (currencies: CurrencyConfig[]) => {
     currencies.forEach((currency) => {
       this.currencies.set(currency.symbol, {
-        maximal: satoshisToWholeCoins(currency.maxSwapAmount),
-        minimal: satoshisToWholeCoins(currency.minSwapAmount),
+        maximal: satoshisToCoins(currency.maxSwapAmount),
+        minimal: satoshisToCoins(currency.minSwapAmount),
       });
     });
   }

--- a/lib/service/ReverseSwapRepository.ts
+++ b/lib/service/ReverseSwapRepository.ts
@@ -5,8 +5,10 @@ import * as db from '../consts/Database';
 class ReverseSwapRepository {
   constructor(private models: Models) {}
 
-  public getReverseSwaps = async () => {
-    return this.models.ReverseSwap.findAll({});
+  public getReverseSwaps = async (options?: WhereOptions<db.ReverseSwapFactory>) => {
+    return this.models.ReverseSwap.findAll({
+      where: options,
+    });
   }
 
   public getReverseSwap = async (options: WhereOptions<db.ReverseSwapFactory>) => {

--- a/lib/service/SwapRepository.ts
+++ b/lib/service/SwapRepository.ts
@@ -5,8 +5,10 @@ import * as db from '../consts/Database';
 class SwapRepository {
   constructor(private models: Models) {}
 
-  public getSwaps = async () => {
-    return this.models.Swap.findAll({});
+  public getSwaps = async (options?: WhereOptions<db.SwapFactory>) => {
+    return this.models.Swap.findAll({
+      where: options,
+    });
   }
 
   public getSwap = async (options: WhereOptions<db.SwapFactory>) => {

--- a/test/unit/Utils.spec.ts
+++ b/test/unit/Utils.spec.ts
@@ -75,6 +75,6 @@ describe('Utils', () => {
   it('convert satoshis to whole coins', () => {
     const randomSat = randomRange(7000);
     const coins = Number((randomSat / 100000000).toFixed(8));
-    expect(utils.satoshisToWholeCoins(randomSat)).to.equal(coins);
+    expect(utils.satoshisToCoins(randomSat)).to.equal(coins);
   });
 });


### PR DESCRIPTION
This PR:

- adds the columns `fee` and `orderSide` to the tables `swaps` and `reverseSwaps`
- adds a new Discord command to get the accumulated fees: `getfees`
- sends a message the Discord channel when a swap is successful