### PR TITLE
fix: catch Discord errors

### DIFF
--- a/lib/notifications/DiscordClient.ts
+++ b/lib/notifications/DiscordClient.ts
@@ -4,6 +4,9 @@ import { Client, TextChannel, Message } from 'discord.js';
 interface DiscordClient {
   on(event: 'message', listener: (message: string) => void): this;
   emit(event: 'message', message: string): boolean;
+
+  on(event: 'error', listener: (error: Error) => void): this;
+  emit(event: 'error', error: Error): boolean;
 }
 
 class DiscordClient extends EventEmitter {
@@ -60,6 +63,10 @@ class DiscordClient extends EventEmitter {
         }
       });
     }
+
+    this.client.on('error', (error) => {
+      this.emit('error', error);
+    });
   }
 }
 

--- a/lib/notifications/NotificationProvider.ts
+++ b/lib/notifications/NotificationProvider.ts
@@ -45,6 +45,7 @@ class NotificationProvider {
     );
 
     this.listenToBoltz();
+    this.listenToDiscord();
     this.listenToService();
 
     new CommandHandler(
@@ -146,8 +147,14 @@ class NotificationProvider {
     }
   }
 
+  private listenToDiscord = () => {
+    this.discord.on('error', (error) => {
+      this.logger.warn(`Discord client threw: ${error.message}`);
+    });
+  }
+
   private listenToBoltz = () => {
-    this.boltz.on('status.updated', async (status: ConnectionStatus) => {
+    this.boltz.on('status.updated', async (status) => {
       switch (status) {
         case ConnectionStatus.Connected:
           if (this.disconnected.has(this.backendName)) {


### PR DESCRIPTION
When the subscription to the Discord [messages threw](https://github.com/discordjs/discord.js/blob/ebfbf20f07574b14f6425aaec2fd0288f3d7c872/src/client/websocket/WebSocketConnection.js#L374), the whole middleware would crash. This PR causes that errors to be handled gracefully.