### PR TITLE
feat: toggle availability of reverse swaps

### DIFF
--- a/lib/consts/Enums.ts
+++ b/lib/consts/Enums.ts
@@ -19,3 +19,7 @@ export enum SwapUpdateEvent {
   TransactionRefunded = 'transaction.refunded',
   TransactionConfirmed = 'transaction.confirmed',
 }
+
+export enum ServiceWarning {
+  ReverseSwapsDisabled = 'reverse.swaps.disabled',
+}

--- a/lib/notifications/CommandHandler.ts
+++ b/lib/notifications/CommandHandler.ts
@@ -7,11 +7,13 @@ import { SwapInstance, ReverseSwapInstance, Swap } from '../consts/Database';
 import { satoshisToCoins, parseBalances, getFeeSymbol, stringify, getSuccessfulTrades } from '../Utils';
 
 enum Command {
-  GetBalance = 'getbalance',
+  Help = 'help',
+
   GetFees = 'getfees',
   SwapInfo = 'swapinfo',
+  GetBalance = 'getbalance',
   NewAddress = 'newaddress',
-  Help = 'help',
+  ToggleReverseSwaps = 'togglereverse',
 }
 
 type CommandInfo = {
@@ -29,11 +31,13 @@ class CommandHandler {
     private discord: DiscordClient) {
 
     this.commands = new Map<string, CommandInfo>([
-      [Command.GetBalance, { description: 'gets the balance of the wallet and channels', executor: this.getBalance }],
-      [Command.GetFees, { description: 'gets the accumulated fees', executor: this.getFees }],
-      [Command.SwapInfo, { description: 'gets all available information about a (reverse) swap', executor: this.swapInfo }],
-      [Command.NewAddress, { description: 'generates a new address for a currency', executor: this.newAddress }],
       [Command.Help, { description: 'gets a list of all available commands', executor: this.help }],
+
+      [Command.GetFees, { description: 'gets the accumulated fees', executor: this.getFees }],
+      [Command.NewAddress, { description: 'generates a new address for a currency', executor: this.newAddress }],
+      [Command.GetBalance, { description: 'gets the balance of the wallet and channels', executor: this.getBalance }],
+      [Command.SwapInfo, { description: 'gets all available information about a (reverse) swap', executor: this.swapInfo }],
+      [Command.ToggleReverseSwaps, { description: 'enables or disables reverse swaps', executor: this.toggleReverseSwaps }],
     ]);
 
     this.discord.on('message', async (message: string) => {
@@ -145,6 +149,12 @@ class CommandHandler {
     } catch (error) {
       await this.discord.sendMessage(`Could not generate address: ${error}`);
     }
+  }
+
+  private toggleReverseSwaps = async () => {
+    this.service.allowReverseSwaps = !this.service.allowReverseSwaps;
+
+    await this.discord.sendMessage(`${this.service.allowReverseSwaps ? 'Enabled' : 'Disabled'} reverse swaps`);
   }
 
   private help = async () => {

--- a/lib/service/Errors.ts
+++ b/lib/service/Errors.ts
@@ -27,4 +27,8 @@ export default {
     message: 'a swap with this invoice exists already',
     code: concatErrorCode(ErrorCodePrefix.Service, 5),
   }),
+  REVERSE_SWAPS_DISABLED: (): Error => ({
+    message: 'reverse swaps are disabled',
+    code: concatErrorCode(ErrorCodePrefix.Service, 6),
+  }),
 };


### PR DESCRIPTION
This PR adds a Discord command that allows for disabling and enabling reverse swaps to mitigate the spam issue a little bit.