### PR TITLE
fix: better error message for non final transactions

### DIFF
--- a/lib/api/Controller.ts
+++ b/lib/api/Controller.ts
@@ -199,12 +199,12 @@ class Controller {
 
   public errorResponse = (res: Response, error: any, statusCode = 400) => {
     if (typeof error === 'string') {
-      this.invalidArgumentsResponse(res, statusCode, error);
+      this.writeErrorResponse(res, statusCode, error);
     } else {
       if (error.details) {
-        this.invalidArgumentsResponse(res, statusCode, error.details);
+        this.writeErrorResponse(res, statusCode, error.details);
       } else {
-        this.invalidArgumentsResponse(res, statusCode, error.message);
+        this.writeErrorResponse(res, statusCode, error.message);
       }
     }
   }
@@ -219,7 +219,7 @@ class Controller {
     res.status(201).json(data);
   }
 
-  private invalidArgumentsResponse = (res: Response, statusCode: number, error: string) => {
+  private writeErrorResponse = (res: Response, statusCode: number, error: string) => {
     this.logger.warn(`Request failed: ${error}`);
 
     this.setContentTypeJson(res);

--- a/lib/service/Errors.ts
+++ b/lib/service/Errors.ts
@@ -31,4 +31,8 @@ export default {
     message: 'reverse swaps are disabled',
     code: concatErrorCode(ErrorCodePrefix.Service, 6),
   }),
+  TRANSACTION_NOT_FINAL: (): Error => ({
+    message: 'please wait until your lockup transaction has 10 confirmations before you try to refund',
+    code: concatErrorCode(ErrorCodePrefix.Service, 7),
+  }),
 };


### PR DESCRIPTION
Closes #82 

This is the new error message:
```
please wait until your lockup transaction has 10 confirmations before you try to refund
```

